### PR TITLE
Update README to reduce duplicated metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,27 +2,16 @@
 
 Verified ERC20-compatible token deployed on **Base Mainnet**.
 
-- **Contract Name:** `BaseToken`
-- **Symbol:** `BASET`
-- **Decimals:** 18  
-- **Total Supply:** 10,000,000,000,000 units
-- **Compiler:** v0.8.24+commit.e11b9ed9  
-- **License:** MIT  
+- Fixed supply: 10,000,000,000,000 units
+- Deployment: October 2025 by **@Igorehadem**
 
-🔗 **Verified on:**
-- [Basescan](https://basescan.org/address/0xc419F1db048B08671c1CA40D4Ac66EaAf452b20a#code)
-- [Sourcify](https://repo.sourcify.dev/8453/0xc419F1db048B08671c1CA40D4Ac66EaAf452b20a/)
-- [Blockscout](https://base.blockscout.com/address/0xc419F1db048B08671c1CA40D4Ac66EaAf452b20a)
-- [Routescan](https://routescan.io/address/0xc419F1db048B08671c1CA40D4Ac66EaAf452b20a/contract/8453/code)
+## Verification & metadata
 
----
+The canonical source for deployment metadata (contract address, compiler settings, license, explorer links, etc.) is [`verification.json`](./verification.json). Update that file first and keep this README as a high-level overview.
 
-Deployed by **@Igorehadem**  
-Verified ✅ on **Base Mainnet**  
-October 2025
+Recent deployment history and verification notes live in [`CHANGELOG.md`](./CHANGELOG.md).
 
+## Related projects
 
-🧠 Related projects:
 - [Farcaster Bot Core](https://github.com/Igorehadem/farcaster-bot-core)
-- [Base Token Contract](https://basescan.org/address/0xc419F1db048B08671c1CA40D4Ac66EaAf452b20a#code)
 - [Base Node (fork)](https://github.com/Igorehadem/node)


### PR DESCRIPTION
## Summary
- streamline the README so it stays a high-level overview of the BaseToken deployment
- point to verification.json and CHANGELOG.md as the canonical sources for metadata and history

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fb4c8784cc8320afe64bf035338663